### PR TITLE
feat(core): add ResponseHandler for standardized API responses

### DIFF
--- a/backend/Core/Bases/Response.cs
+++ b/backend/Core/Bases/Response.cs
@@ -1,0 +1,78 @@
+using System.Net;
+
+namespace Core.Bases;
+
+public class Response<T>
+{
+    public HttpStatusCode StatusCode { get; }
+    public object? Meta { get; }
+    public bool Succeeded { get; }
+    public string? Message { get; }
+    public List<string>? Errors { get; }
+    public T? Data { get; }
+    private Response(HttpStatusCode statusCode, object? meta, bool succeeded, string? message, List<string>? errors, T? data)
+    {
+        StatusCode = statusCode;
+        Meta = meta;
+        Succeeded = succeeded;
+        Message = message;
+        Errors = errors;
+        Data = data;
+    }
+
+    public class Builder
+    {
+        private HttpStatusCode _statusCode = HttpStatusCode.OK;
+        private  object? _meta;
+        private bool _succeeded = true;
+        private  string? _message ;
+        private List<string>? _errors;
+        private T? _data;
+
+        public Builder WithStatusCode(HttpStatusCode statusCode)
+        {
+            _statusCode = statusCode;
+            return this;
+        }
+
+        public Builder WithMeta(object? meta)
+        {
+            _meta = meta;
+            return this;
+        }
+
+        public Builder WithSucceeded(bool succeeded)
+        {
+            _succeeded = succeeded;
+            return this;
+        }
+
+        public Builder WithMessage(string? message)
+        {
+            _message = message;
+            return this;
+        }
+
+        public Builder WithErrors(List<string>? errors)
+        {
+            _errors = errors;
+            return this;
+        }
+
+        public Builder WithData(T data)
+        {
+            _data = data;
+            return this;
+        }
+
+        public Response<T> Build()
+        {
+            return new Response<T>(_statusCode, _meta, _succeeded, _message, _errors, _data);
+        }
+    }
+
+    public static Builder CreateBuilder()
+    {
+        return new Builder();
+    }
+}

--- a/backend/Core/Bases/ResponseHandler.cs
+++ b/backend/Core/Bases/ResponseHandler.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Net;
+using Core.SharedResources;
+using Microsoft.Extensions.Localization;
+
+namespace Core.Bases;
+
+public class ResponseHandler
+{
+    private readonly IStringLocalizer _stringLocalizer;
+
+
+    public ResponseHandler(IStringLocalizer stringLocalizer)
+    {
+        _stringLocalizer = stringLocalizer;
+    }
+
+    public Response<T> Deleted<T>(string? message = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithStatusCode(HttpStatusCode.OK)
+            .WithSucceeded(true)
+            .WithMessage(message ?? _stringLocalizer[Keys.Deleted])
+            .Build();
+    }
+
+    public Response<T> InternalServerError<T>()
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithStatusCode(HttpStatusCode.InternalServerError)
+            .WithSucceeded(false)
+            .WithMessage("InternalServerError")
+            .Build();
+    }
+
+    public Response<T> Success<T>(T entity, object? meta = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithData(entity)
+            .WithStatusCode(HttpStatusCode.OK)
+            .WithSucceeded(true)
+            .WithMessage(_stringLocalizer[Keys.Success])
+            .WithMeta(meta)
+            .Build();
+    }
+
+    public Response<T> Unauthorized<T>(string? message = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithStatusCode(HttpStatusCode.Unauthorized)
+            .WithSucceeded(false)
+            .WithMessage(message ?? _stringLocalizer[Keys.UnAuthorized])
+            .Build();
+    }
+
+    public Response<T> BadRequest<T>(string? message = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithStatusCode(HttpStatusCode.BadRequest)
+            .WithSucceeded(false)
+            .WithMessage(message ?? _stringLocalizer[Keys.BadRequest])
+            .Build();
+    }
+
+    public Response<T> UnprocessableEntity<T>(string? message = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithStatusCode(HttpStatusCode.UnprocessableEntity)
+            .WithSucceeded(false)
+            .WithMessage(message ?? _stringLocalizer[Keys.UnprocessableEntity])
+            .Build();
+    }
+
+    public Response<T> NotFound<T>(string? message = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithStatusCode(HttpStatusCode.NotFound)
+            .WithSucceeded(false)
+            .WithMessage(message ?? _stringLocalizer[Keys.NotFound])
+            .Build();
+    }
+
+    public Response<T> Created<T>(T entity, object? meta = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithData(entity)
+            .WithStatusCode(HttpStatusCode.Created)
+            .WithSucceeded(true)
+            .WithMessage(_stringLocalizer[Keys.Created])
+            .WithMeta(meta)
+            .Build();
+    }
+
+    public Response<T> Conflict<T>(T entity, object? meta = null)
+    {
+        return Response<T>
+            .CreateBuilder()
+            .WithData(entity)
+            .WithStatusCode(HttpStatusCode.Conflict)
+            .WithSucceeded(false)
+            .WithMessage(_stringLocalizer[Keys.Conflict])
+            .WithMeta(meta)
+            .Build();
+    }
+}

--- a/backend/Core/Core.csproj
+++ b/backend/Core/Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/backend/Core/SharedResources/Kyes.cs
+++ b/backend/Core/SharedResources/Kyes.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Core.SharedResources;
+
+public class Keys
+{
+    public const string NotFound = "NotFound";
+    public const string BadRequest = "BadRequest";
+    public const string Deleted = "Deleted";
+    public const string Created = "Created";
+    public const string Conflict = "Conflict";
+    public const string UnAuthorized = "UnAuthorized";
+    public const string UnprocessableEntity = "UnprocessableEntity";
+    public const string Success = "Success";
+}


### PR DESCRIPTION
## Description
This PR introduces a `ResponseHandler` class to the Core layer, providing a standardized way to generate API responses across the application. The `ResponseHandler` integrates with the existing `Response<T>` class and `Keys` for localization, ensuring consistent and maintainable response handling.

## Changes
- Added `ResponseHandler` class with utility methods for common API responses:
  - `Success`
  - `Created`
  - `BadRequest`
  - `Unauthorized`
  - `NotFound`
  - `Conflict`
  - `UnprocessableEntity`
  - `InternalServerError`
- Integrated with the `Response<T>` class and its builder pattern for flexible response construction.
- Utilized the `Keys` class for localized message keys, ensuring consistency in response messages.

## Why This Is Needed
- Standardizes API response handling across the application.
- Reduces boilerplate code by encapsulating common response logic in a single class.
- Improves maintainability and readability of API endpoint implementations.


## Related Tickets
- [ClickUp Ticket](https://app.clickup.com/t/8697q0ch5)

## Notes
- This PR does not introduce any breaking changes.
- The branch has been pushed to the remote repository but is not yet merged.

## Checklist
- [x] Code follows the project's coding standards.