### PR TITLE
Refactor/nullable references

### DIFF
--- a/backend/Infrastracture/Base/GenericRepository.cs
+++ b/backend/Infrastracture/Base/GenericRepository.cs
@@ -31,7 +31,7 @@ namespace Infrastracture.Base
         #endregion
 
         #region Actions
-        public virtual async Task<T> GetByIdAsync(long id)
+        public virtual async Task<T?> GetByIdAsync(long id)
         {
 
             return await _dbContext.Set<T>().FindAsync(id);

--- a/backend/Infrastracture/Base/IGenericRepository.cs
+++ b/backend/Infrastracture/Base/IGenericRepository.cs
@@ -10,7 +10,7 @@ namespace Infrastracture.Base
     public interface IGenericRepository<T> where T : class
     {
         Task DeleteRangeAsync(ICollection<T> entities);
-        Task<T> GetByIdAsync(long id);
+        Task<T?> GetByIdAsync(long id);
         Task SaveChangesAsync();
         IDbContextTransaction BeginTransaction();
         void Commit();

--- a/backend/Service/ServiceBase/GenericServices.cs
+++ b/backend/Service/ServiceBase/GenericServices.cs
@@ -27,7 +27,7 @@ namespace ServiceLayer.ServiceBase
         }
 
         // Get by Id
-        public async Task<T> GetByIdAsync(long id)
+        public async Task<T?> GetByIdAsync(long id)
         {
             return await _repository.GetByIdAsync(id);
         }

--- a/backend/Service/ServiceBase/IGenericService.cs
+++ b/backend/Service/ServiceBase/IGenericService.cs
@@ -10,7 +10,7 @@ namespace ServiceLayer.ServiceBase
     public interface IGenericService<T> where T : class
     {
         Task<T> AddAsync(T entity);
-        Task<T> GetByIdAsync(long id);
+        Task<T?> GetByIdAsync(long id);
         Task<List<T>> GetListAsync();
         Task UpdateAsync(T entity);
         Task DeleteAsync(T entity);


### PR DESCRIPTION
### Pull Request Summary

**Title**: Refactor `GetByIdAsync` to Return Nullable Type  
**Branch**: (Your branch name)  
**Target Branch**: (e.g., `main`, `develop`)  
**Author**: @akram777077  

---

#### Description
This PR refactors the `GetByIdAsync` method in both the generic repository and service layers to return a nullable type (`T?`). This change improves type safety, aligns with C# 8+ nullable reference types, and ensures clarity for consumers of the method by requiring explicit handling of potential `null` results.

---

#### Changes
1. **Generic Repository**:
   - Updated method signature from `Task<T>` to `Task<T?>`.
   - Ensures the method explicitly handles nullable return values.

2. **Service Method**:
   - Updated method signature from `Task<T>` to `Task<T?>`.
   - Aligns with the underlying repository method and improves consistency.

---

#### Impact
- Consumers of these methods will now need to handle `null` results explicitly.
- Enhances code clarity and reduces the risk of runtime issues related to null values.

---

#### Related Commits
- `refactor(generic-repository): update GetByIdAsync to return nullable type`  
  - Changed method signature to `Task<T?>` for nullable return values.  
  - Improves type safety and aligns with C# 8+ nullable reference types.  
  - Ensures clarity for consumers of the method.  

- `refactor(service-method): update GetByIdAsync to return nullable type`  
  - Updated method signature to `Task<T?>` to align with the repository method.  
  - Ensures consistency and improves type safety.  
  - Requires consumers to handle potential `null` results.  