### PR TITLE
🚀 feat(category): Add delete category functionality

### DIFF
--- a/backend/API/Controllers/CategoriesController.cs
+++ b/backend/API/Controllers/CategoriesController.cs
@@ -4,6 +4,7 @@ using Core.Featurs.Categories.Queries.Resquests;
 using Data.AppMetaData;
 using Data.Entities;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -81,6 +82,20 @@ namespace API.Controllers
         public async Task<ActionResult<Category>> Edit([FromBody] EditCategoryCommande categoryCommande)
         {
             var response = await _mediator.Send(categoryCommande);
+            return NewResult(response);
+        }
+
+        [HttpDelete]
+        [Route(Router.CategoryRouteing.Delete)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<Category>> Delete([FromRoute] int Id)
+        {
+            var response = await _mediator.Send(new DeleteCategoryCommand { Id = Id });
             return NewResult(response);
         }
     }

--- a/backend/Core/Featurs/Categories/Commands/Handlers/CategoryCommandsHandler.cs
+++ b/backend/Core/Featurs/Categories/Commands/Handlers/CategoryCommandsHandler.cs
@@ -16,7 +16,8 @@ namespace Core.Featurs.Categories.Commands.Handlers
 {
     public class CategoryCommandsHandler : ResponseHandler,
         IRequestHandler<CreateCategoryCommand, Response<string>>,
-        IRequestHandler<EditCategoryCommande, Response<string>>
+        IRequestHandler<EditCategoryCommande, Response<string>>,
+        IRequestHandler<DeleteCategoryCommand, Response<string>>
     {
         #region Properties
         private readonly IMapper _mapper;
@@ -53,6 +54,23 @@ namespace Core.Featurs.Categories.Commands.Handlers
             await _categoryService.UpdateAsync(category);
             return Success("");
 
+        }
+
+        public async Task<Response<string>> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
+        {
+            //check if Id exists
+            var category = await _categoryService.GetByIdAsync(request.Id);
+
+            //return not found if not exist
+            if (category == null)
+                return NotFound<string>();
+
+            //cal the edit service
+            var result = await _categoryService.DeleteAsync(category);
+
+            //return response
+            if (result == "Deleted") return Deleted<string>("");
+            else return InternalServerError<string>();
         }
         #endregion
     }

--- a/backend/Core/Featurs/Categories/Commands/Requests/DeleteCategoryCommand.cs
+++ b/backend/Core/Featurs/Categories/Commands/Requests/DeleteCategoryCommand.cs
@@ -1,0 +1,16 @@
+﻿using Core.Bases;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.Featurs.Categories.Commands.Requests
+{
+    public class DeleteCategoryCommand : IRequest<Response<string>>
+    {
+        public int Id { get; set; }
+    }
+}
+

--- a/backend/Service/ServiceBase/GenericServices.cs
+++ b/backend/Service/ServiceBase/GenericServices.cs
@@ -41,9 +41,21 @@ namespace ServiceLayer.ServiceBase
 
         
         // Delete a single entity
-        public async Task DeleteAsync(T entity)
+        public async Task<string> DeleteAsync(T entity)
         {
-            await _repository.DeleteAsync(entity);
+            var transaction = _repository.BeginTransaction();
+            try
+            {
+                await _repository.DeleteAsync(entity);
+                transaction.Commit();
+                return "Deleted";
+            }
+            catch (Exception)
+            {
+
+                transaction.Rollback();
+                return "Faild";
+            }
         }
 
         public async Task<IEnumerable<T>> GetListAsync()

--- a/backend/Service/ServiceBase/IGenericService.cs
+++ b/backend/Service/ServiceBase/IGenericService.cs
@@ -13,7 +13,7 @@ namespace ServiceLayer.ServiceBase
         Task<T?> GetByIdAsync(long id);
         Task<IEnumerable<T>> GetListAsync();
         Task UpdateAsync(T entity);
-        Task DeleteAsync(T entity);
+        Task<string> DeleteAsync(T entity);
     }
 
 }


### PR DESCRIPTION
# Pull Request
## Summary:
- Introduces the ability to delete categories via the API, refactors service return types, 
 and ensures consistency across the application.

## Changes:
- Added `Delete` endpoint in `CategoriesController.cs` to handle HTTP DELETE requests.
- Implemented `DeleteCategoryCommand` handler in `CategoryCommandsHandler.cs` to process deletions.
- Created `DeleteCategoryCommand` class in `DeleteCategoryCommand.cs` for structured command handling.
- Modified `DeleteAsync` method in `GenericServices.cs` to return a `String` instead of `Void` for better response handling.
- Updated `IGenericService.cs` interface to reflect the return type change for `DeleteAsync`.

## Why This Change?
- Enables category deletion through a dedicated API endpoint.
- Improves feedback by returning a message upon successful deletion.
- Enhances consistency in the service layer by adjusting return types.

## How to Test:
1. Send a DELETE request to the `Delete` endpoint with a valid category ID.
2. Ensure the category is removed from the database.
3. Verify that a success message is returned.
4. Attempt deletion with an invalid/non-existent ID and confirm proper error handling.

## Next Steps:
**🔹 Implement soft-delete functionality if needed.**
**🔹 Consider logging deletions for audit purposes.**

> ✅ Ready for review! Feedback and suggestions are welcome.